### PR TITLE
VS2012 compatibility for examples

### DIFF
--- a/example-pointcloud/example-pointcloud.vcxproj
+++ b/example-pointcloud/example-pointcloud.vcxproj
@@ -19,13 +19,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v110</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v110</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">

--- a/example-simple/example-simple.vcxproj
+++ b/example-simple/example-simple.vcxproj
@@ -19,13 +19,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v110</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v110</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">

--- a/example-simple/src/ofApp.cpp
+++ b/example-simple/src/ofApp.cpp
@@ -22,9 +22,13 @@ void ofApp::setup()
 		int cW = static_cast<int>(mRSSDK.getWidth());
 		int cH = static_cast<int>(mRSSDK.getHeight());
 		mDepthColorTex.allocate(cW, cH, GL_RGB);
-		mDepthColorPixels = new uint8_t[cW*cH * 3]{0};
+		mDepthColorPixels = new uint8_t[cW*cH * 3];
 		mNearColor = ofColor(255, 0, 0);
 		mFarColor = ofColor(20, 40, 255);
+
+		for (int i = 0; i < cW*cH*3; i++) {
+			mDepthColorPixels[i] = 0;
+		}
 	}
 
 }

--- a/src/ofxRSSDK.cpp
+++ b/src/ofxRSSDK.cpp
@@ -241,8 +241,8 @@ ofVec3f ofxRSSDK::getWorldCoordinateAt(float cx, float cy, float wz)
 {
 	PXCPoint3DF32 cDepthPoint;
 	cDepthPoint.x = cx; cDepthPoint.y = cy; cDepthPoint.z = wz;
-	PXCPoint3DF32 cDepth[1]{cDepthPoint};
-	PXCPoint3DF32 cCamera[1]{PXCPoint3DF32()};
+	PXCPoint3DF32 cDepth[1] = {cDepthPoint};
+	PXCPoint3DF32 cCamera[1] = {PXCPoint3DF32()};
 	mProjection->ProjectDepthToCamera(1, cDepth, cCamera);
 	
 	return ofVec3f(cCamera[0].x, cCamera[0].y, cCamera[0].z);


### PR DESCRIPTION
Hey Seth, thanks for working on this! I made a couple changes to get the examples to run on Windows 8.1/VS2012 with OF 0.8.4, mostly getting rid of some C++11 syntax and changing the solutions file. Thanks to @num3ric as well for the help ;)
